### PR TITLE
docs(readme): importación guía de ejecución, scripts de copia y comprobaciones rápidas

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,120 @@ python -m pip install --upgrade pip
 pip install pathspec
 ```
 
+Nota rápida (si el comando `venv` se queda bloqueado o muestra una traza con `ensurepip`):
+
+- En Windows intenta usar el lanzador: `py -3 -m venv .venv` y luego `.\.venv\Scripts\Activate.ps1`.
+- Si sigue fallando, crea el entorno sin `pip` y haz bootstrap manualmente:
+	```powershell
+	python -m venv .venv --without-pip
+	Invoke-WebRequest -UseBasicParsing https://bootstrap.pypa.io/get-pip.py -OutFile get-pip.py
+	.\.venv\Scripts\python.exe get-pip.py
+	```
+- Alternativa: si el entorno ya está activado pero falta `pip`, ejecuta dentro del venv:
+	```powershell
+	python -m ensurepip --upgrade
+	```
+
+Qué esperar al ejecutar el wrapper:
+
+- `--dry-run` o elegir "Simulación" en el menú no escribe archivos; solo muestra qué se haría.
+- Ejecución real escribe tiddlers JSON en `tiddlers-export/` (copias gzip en `tiddlers-export/large/` si usas `--include-large --large-action copy`).
+
+Copiar `repository-export` a otro repo (scripts)
+
+Si prefieres copiar la carpeta completa y excluir metadata/artefactos locales, hay scripts útiles en `scripts/`:
+
+- `scripts/copy_repo.sh` — bash/rsync (Linux/macOS)
+- `scripts/copy_repo.ps1` — PowerShell/Robocopy (Windows)
+
+Ejemplo (bash):
+```bash
+# desde el directorio que contiene repository-export
+./scripts/copy_repo.sh ./repository-export /ruta/al/repo/tools/repository-export
+```
+
+Ejemplo (PowerShell):
+```powershell
+# desde la carpeta del proyecto
+.\scripts\copy_repo.ps1 -Source .\repository-export -Dest D:\ruta\al\repo\tools\repository-export
+```
+
+Ambos excluyen por defecto: `.git`, `.venv`, `tiddlers-export`, `__pycache__` y `.pytest_cache`.
+
+Comprobaciones rápidas (ver que todo está listo)
+
+```powershell
+# 1) Versión de Python
+python --version
+
+# 2) Ejecutable usado
+python -c "import sys; print(sys.executable)"
+
+# 3) Pip y paquete necesario
+python -m pip --version
+python -m pip show pathspec || pip install pathspec
+
+# 4) Dry-run del exportador (no escribe archivos)
+python rep_export_Windows\tiddler_exporter_windows.py --dry-run --root . --new-schema
+
+# 5) Listar salidas (si ejecutas real export)
+Get-ChildItem -Recurse .\tiddlers-export\ | Select-Object FullName, Length
+```
+
+Salir del entorno virtual (`venv`)
+
+- En PowerShell o Command Prompt (Windows):
+```powershell
+deactivate
+# o cerrar la ventana de la terminal
+```
+- En bash (Linux/macOS):
+```bash
+deactivate
+# o cerrar la terminal
+```
+
+### Requisitos para desarrollo y tests
+
+Para ejecutar los tests y trabajar en el proyecto localmente, tras crear y activar el entorno virtual instale las dependencias de desarrollo:
+
+En Windows (PowerShell):
+```powershell
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+pip install pathspec pytest
+```
+
+En Linux / macOS (bash):
+```bash
+source .venv/bin/activate
+python -m pip install --upgrade pip
+pip install pathspec pytest
+```
+
+Opcional (recomendado para facilitar imports locales):
+```bash
+pip install -e .
+```
+
+Configuración recomendada para VS Code
+
+- Seleccione el intérprete del proyecto: `Ctrl+Shift+P` → `Python: Select Interpreter` → elija el `.venv` del proyecto.
+- (Opcional) Añada `.vscode/settings.json` con las siguientes opciones para que Pylance indexe los módulos locales y habilite `pytest` en el panel de tests:
+
+```json
+{
+	"python.analysis.extraPaths": [
+		"rep_export_Windows",
+		"rep_export_LINUXandMAC"
+	],
+	"python.testing.pytestEnabled": true,
+	"python.testing.pytestArgs": ["tests"]
+}
+```
+
+Con esto Pylance dejará de mostrar advertencias "could not be resolved" para los módulos locales y VS Code podrá ejecutar `pytest` desde el panel de tests.
+
 Nota sobre detección de raíz: los scripts principales aceptan la opción `--root <ruta>` y respetan la variable de entorno `REPO_EXPORT_ROOT`. Úsalo cuando la herramienta esté anidada dentro de otro repositorio para forzar la raíz objetivo.
 
 ### Archivos grandes

--- a/rep_export_LINUXandMAC/ejecucion_unix.md
+++ b/rep_export_LINUXandMAC/ejecucion_unix.md
@@ -1,0 +1,74 @@
+# Ejecución — Linux / macOS (usar cuando sólo pegaste `rep_export_LINUXandMAC`)
+
+Guía rápida para ejecutar la herramienta después de copiar `rep_export_LINUXandMAC` dentro de otro repositorio.
+
+## Escenario
+Copiaste `rep_export_LINUXandMAC` al root del repo (por ejemplo `tools/repository-export` o en la raíz del proyecto).
+
+## Requisitos
+- Python 3.7+
+- `tree` (opcional para estructura ASCII)
+- bash/zsh
+
+## Preparar el entorno
+```bash
+cd /ruta/al/repo
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+pip install pathspec
+# opcional (tests)
+pip install pytest
+```
+Si `venv` falla por `ensurepip` revisa `README.md` para la opción `--without-pip` + `get-pip.py`.
+
+## Uso interactivo (wrapper)
+```bash
+python3 rep-export-LINUXandMAC/scripts/export_structure_wrapper_unix.py
+```
+Elige `2` para exportar tiddlers JSON o `3` para generar estructura y exportar.
+
+## Ejecución directa (dry-run)
+```bash
+python3 rep_export_LINUXandMAC/tiddler_exporter_UNIX.py --dry-run --root . --new-schema
+```
+
+## Ejecución real
+```bash
+python3 rep_export_LINUXandMAC/tiddler_exporter_UNIX.py --root . --new-schema
+```
+Incluyendo archivos grandes:
+```bash
+python3 rep_export_LINUXandMAC/tiddler_exporter_UNIX.py --root . --include-large --large-action preview
+# forzar limite a 5MB
+python3 rep_export_LINUXandMAC/tiddler_exporter_UNIX.py --root . --max-size 5242880
+```
+O usar variable de entorno:
+```bash
+export REPO_EXPORT_MAX_FILE_SIZE=5242880
+python3 rep_export_LINUXandMAC/tiddler_exporter_UNIX.py --root . --include-large
+```
+
+## Verificar salida
+```bash
+ls -R tiddlers-export | sed -n '1,200p'
+# ver un JSON
+cat tiddlers-export/<archivo>.json | less
+```
+
+## Comprobaciones rápidas
+```bash
+python3 --version
+python3 -c 'import sys; print(sys.executable)'
+python3 -m pip --version
+```
+
+## Salir del venv
+```bash
+deactivate
+# o cerrar la terminal
+```
+
+## Notas
+- Usa `--dry-run` primero si no estás seguro del resultado.
+- Si la carpeta está anidada y la detección de raíz no es la esperada, fuerza la raíz con `--root <ruta>` o define `REPO_EXPORT_ROOT`.

--- a/rep_export_Windows/ejecucion_windows.md
+++ b/rep_export_Windows/ejecucion_windows.md
@@ -1,0 +1,91 @@
+# Ejecución — Windows (usar cuando sólo pegaste `rep_export_Windows`)
+
+Este documento explica los pasos mínimos para usar `rep_export_Windows` después de copiar únicamente esa carpeta dentro de otro repositorio.
+
+**Escenario:** copiaste la carpeta `rep_export_Windows` al root de tu repo (ej.: `tools/repository-export` o directamente en la raíz).
+
+## Requisitos rápidos
+- Python 3.7+
+- PowerShell
+- (Opcional) `tree` si quieres la opción de estructura ASCII
+
+## Preparar el entorno
+Abrir PowerShell en la raíz del repo (donde esté la carpeta `rep_export_Windows`) y crear/activar el venv:
+
+```powershell
+# crea y activa (usa el lanzador py para evitar problemas con ensurepip)
+py -3 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+
+# actualizar pip e instalar dependencia mínima
+python -m pip install --upgrade pip
+pip install pathspec
+# opcional (tests)
+pip install pytest
+```
+
+Si `venv` falla por `ensurepip`, ver `README.md` (opciones: `--without-pip`, `get-pip.py`, o `virtualenv`).
+
+## Uso interactivo (wrapper)
+Ejecuta el wrapper que muestra el menú y manejo de archivos grandes:
+
+```powershell
+python rep_export_Windows\scripts_windows\export_structure_wrapper_windows.py
+```
+
+- Elige `2` para exportar tiddlers (o `3` para generar estructura y exportar).
+- Responde `y` si quieres `dry-run` primero (recomendado).
+
+## Ejecución directa (dry-run)
+Prueba sin escribir archivos:
+
+```powershell
+python rep_export_Windows\tiddler_exporter_windows.py --dry-run --root . --new-schema
+```
+
+## Ejecución real (genera JSON)
+Para generar los tiddlers:
+
+```powershell
+python rep_export_Windows\tiddler_exporter_windows.py --root . --new-schema
+```
+
+Incluir archivos grandes (opciones: `preview`, `copy`, `embed`):
+
+```powershell
+python rep_export_Windows\tiddler_exporter_windows.py --root . --include-large --large-action copy
+# o forzar límite a 5 MB
+python rep_export_Windows\tiddler_exporter_windows.py --root . --max-size 5242880 --include-large --large-action preview
+```
+
+También puedes usar la variable de entorno:
+
+```powershell
+$env:REPO_EXPORT_MAX_FILE_SIZE = '5242880'
+python rep_export_Windows\tiddler_exporter_windows.py --root . --include-large
+```
+
+## Verificar salida
+Los tiddlers se escriben en `tiddlers-export/` (en la carpeta donde ejecutaste el script):
+
+```powershell
+Get-ChildItem -Recurse .\tiddlers-export\ | Select-Object FullName, Length
+Get-Content .\tiddlers-export\<algún-archivo>.json -Raw
+```
+
+## Comprobaciones rápidas
+```powershell
+python --version
+python -c "import sys; print(sys.executable)"
+python -m pip --version
+```
+
+## Salir del `venv`
+```powershell
+deactivate
+# o cerrar la ventana de la terminal
+```
+
+## Nota corta
+- El wrapper hace un escaneo previo y ofrece opciones para archivos grandes; usa `dry-run` si no estás seguro.
+- Si quieres integrarlo de forma limpia en muchos repos (recomendado), usa `git submodule` o los scripts de copia en `scripts/`.

--- a/scripts/copy_repo.ps1
+++ b/scripts/copy_repo.ps1
@@ -1,0 +1,34 @@
+# scripts/copy_repo.ps1
+# Copia repository-export a otro directorio excluyendo .git, .venv y tiddlers-export
+# Uso: .\scripts\copy_repo.ps1 -Source . -Dest D:\ruta\al\repo\tools\repository-export
+param(
+  [string]$Source = '.',
+  [string]$Dest
+)
+
+if (-not $Dest) {
+  Write-Host "Usage: .\scripts\copy_repo.ps1 -Source <source> -Dest <dest>"
+  exit 2
+}
+
+$srcPath = (Resolve-Path -Path $Source).ProviderPath
+$destPath = (Resolve-Path -LiteralPath $Dest -ErrorAction SilentlyContinue)
+if (-not $destPath) { New-Item -ItemType Directory -Path $Dest | Out-Null }
+$destPath = (Resolve-Path -Path $Dest).ProviderPath
+
+# Prevención: no copiar dentro de sí mismo
+if ($destPath.StartsWith($srcPath)) {
+  Write-Error "Destination must not be inside the source. Choose another folder."; exit 3
+}
+
+# Robocopy. /MIR mirrors, /XD excludes directories
+$excludeDirs = @('.git', '.venv', 'tiddlers-export', '__pycache__', '.pytest_cache')
+$xd = $excludeDirs -join ' '
+
+$robocopyArgs = @($Source, $Dest, '/MIR', '/R:2', '/W:2') + ('/XD') + $excludeDirs
+
+# Ejecutar Robocopy
+Write-Host "Running Robocopy from $Source to $Dest (excluding: $xd)"
+robocopy @robocopyArgs | Out-Null
+
+Write-Host "Copy complete: $Source -> $Dest"

--- a/scripts/copy_repo.sh
+++ b/scripts/copy_repo.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# scripts/copy_repo.sh
+# Copia el contenido de repository-export a otro directorio excluyendo .git, .venv y tiddlers-export
+# Uso: ./scripts/copy_repo.sh /ruta/al/repository-export /ruta/destino
+
+set -euo pipefail
+SRC=${1:-.}
+DST=${2:-}
+
+if [ -z "$DST" ]; then
+  echo "Usage: $0 <source-dir> <dest-dir>"
+  exit 2
+fi
+
+# Evitar copiar dentro de sí mismo
+real_src=$(realpath "$SRC")
+real_dst=$(realpath "$DST" 2>/dev/null || true)
+if [ -n "$real_dst" ] && [[ "$real_dst" == "$real_src"* ]]; then
+  echo "Error: destination must not be inside the source. Choose another folder."
+  exit 3
+fi
+
+mkdir -p "$DST"
+
+rsync -av --delete \
+  --exclude='.git' \
+  --exclude='.venv' \
+  --exclude='tiddlers-export' \
+  --exclude='__pycache__' \
+  --exclude='.pytest_cache' \
+  "${SRC%/}/" "$DST/"
+
+echo "Copied ${SRC} -> ${DST} (excludes: .git, .venv, tiddlers-export)" 


### PR DESCRIPTION
# docs(readme): importación guía de ejecución, scripts de copia y comprobaciones rápidas

## Metadatos

| Campo     | Valor   |
|-----------|---------|
| Estado    | listo   |
| Vuelta    | 1       |
| Radio     | 1       |
| Madurez   | estable |
| Bloque    | docs    |
| Delta-r   | +6      |
| Delta-c   | +150    |

`Meta: V1|R1|C1|Bdocs|Dr:+6|Dc:+150`

---

## Objetivo

Proveer instrucciones mínimas de uso e instalación cuando se copia la carpeta del exportador dentro de otro repositorio, facilitar la resolución rápida de problemas con `venv`, añadir scripts seguros de copia y ofrecer guías de ejecución separadas para Windows y Unix.

---

## Acciones realizadas

- Actualizado `README.md`:
  - Instrucciones de entorno (venv), instalación mínima (`pathspec`) y tests (`pytest`).
  - Nota corta para troubleshooting de `venv` (opción `--without-pip`, `get-pip.py`, `virtualenv`).
  - Comprobaciones rápidas y ejemplos de dry-run / ejecución real.
  - Indicación para salir del `venv`.
  - Referencia a los scripts de copia y guía VS Code.
- Añadido `.vscode/settings.json` con `python.analysis.extraPaths` y configuración básica de `pytest` para reducir advertencias de Pylance y facilitar ejecución de tests desde VS Code.
- Añadidos scripts de ayuda para copiar la carpeta sin metadata:
  - `scripts/copy_repo.sh` (rsync) — Linux / macOS
  - `scripts/copy_repo.ps1` (robocopy) — Windows
  - Ambos excluyen `.git`, `.venv`, `tiddlers-export`, `__pycache__`, `.pytest_cache`.
- Creación de guías específicas de uso cuando sólo se copia la carpeta:
  - `ejecucion_windows.md`
  - `ejecucion_unix.md`
  - Contienen pasos de preparación, dry-run, ejecución real, flags útiles y verificación de salida.

---

## Archivos modificados / añadidos

- `README.md` — actualizada con entorno, troubleshooting, quick checks y sección de copia
- `.vscode/settings.json` — añadido (recomendado)
- `scripts/copy_repo.sh` — añadido
- `scripts/copy_repo.ps1` — añadido
- `ejecucion_windows.md` — añadido
- `ejecucion_unix.md` — añadido

---

## Comprobaciones sugeridas

- Ejecutar dry-run (no escribe archivos):
  ```
  python rep_export_Windows\tiddler_exporter_windows.py --dry-run --root . --new-schema
  ```
- Ejecutar export real (genera `tiddlers-export/`):
  ```
  python rep_export_Windows\tiddler_exporter_windows.py --root . --new-schema
  ```
- Probar scripts de copia en directorio de prueba:
  - Bash: `./scripts/copy_repo.sh ./repository-export /ruta/al/repo/tools/repository-export`
  - PowerShell: `.\\scripts\\copy_repo.ps1 -Source .\\repository-export -Dest D:\\ruta\\al\\repo\\tools\\repository-export`
- Verificar que `.vscode/settings.json` reduce los avisos de imports en VS Code y que `pytest` se puede ejecutar desde el panel de tests.
- Revisar que la documentación es clara y compacta para usuarios que peguen sólo la carpeta del exportador.

---

## Notas para el revisor

- Cambios exclusivamente documentales y de ergonomía; no se modifica la lógica del exportador.
- Las guías `ejecucion_*.md` están diseñadas para ser copy-pasteables y breves.
- Recomendado: aceptar el PR en la rama `exporter` o similar, y opcionalmente añadir `scripts/` a `.gitignore` del proyecto anfitrión si no deseas incluirlos como archivos persistentes.
