### PR TITLE
normalización(export): etiquetas iguales al título y simplificación del menú de exportación

### DIFF
--- a/rep_export_LINUXandMAC/scripts/export_structure_wrapper_unix.py
+++ b/rep_export_LINUXandMAC/scripts/export_structure_wrapper_unix.py
@@ -162,8 +162,7 @@ def main():
                 if prompt_yes_no("Error al exportar. Volver al menú?", default=True):
                     continue
                 sys.exit(code)
-            if '--dry-run' in exp_args:
-                safe_print("\n🚀 Ejecutando exportación real...")
+            if '--dry-run' in exp_args and prompt_yes_no("Dry-run completado. Ejecutar real?", default=True):
                 real_args = [a for a in exp_args if a != '--dry-run']
                 code, _, _ = run_cmd([sys.executable, str(export)] + real_args, cwd=base)
                 if code != 0:

--- a/rep_export_Windows/scripts_windows/export_structure_wrapper_windows.py
+++ b/rep_export_Windows/scripts_windows/export_structure_wrapper_windows.py
@@ -157,8 +157,7 @@ def main():
                 if cli_utils_Windows.prompt_yes_no("Error al exportar. Volver al menú?", default=True):
                     continue
                 sys.exit(code)
-            if '--dry-run' in exp_args:
-                cli_utils_Windows.safe_print("\n🚀 Ejecutando exportación real...")
+            if '--dry-run' in exp_args and cli_utils_Windows.prompt_yes_no("Dry-run completado. Ejecutar real?", default=True):
                 real_args = [a for a in exp_args if a != '--dry-run']
                 code, _, _ = cli_utils_Windows.run_cmd([sys.executable, str(export)] + real_args, cwd=base)
                 if code != 0:


### PR DESCRIPTION
# normalización(export): etiquetas iguales al título y simplificación del menú de exportación

Estado: listo
Vuelta: 2
Radio: 1
Madurez: estable
Bloque: export
Delta-r: 0
Delta-c: +0.5

- Normaliza `get_tags_for_file()` para que el tag coincida exactamente con `safe_title()` (usa `rel.as_posix()`).
- Elimina el prefijo `-` y la conversión de separadores a `_` en los nombres de tag.
- Elimina código muerto (`alguna_funcion()`).
- Simplifica los wrappers: quita prompts de "args extra" y restaura confirmación tras `--dry-run`.
- Elimina el flag/argumento `--new-schema` y el parámetro `use_new_schema` (el esquema extendido es ahora comportamiento por defecto).

Archivos modificados:
- rep_export_Windows/tag_mapper_windows.py
- rep_export_LINUXandMAC/tag_mapper_UNIX.py
- rep_export_Windows/scripts_windows/export_structure_wrapper_windows.py
- rep_export_LINUXandMAC/scripts/export_structure_wrapper_unix.py
- rep_export_Windows/tiddler_exporter_windows.py

Meta: V2|R1|C2|Bexport|Dr:0|Dc:+0.5